### PR TITLE
Ignore stylesheets extracted from html files

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function gulpuncss(optimise) {
             stream.push(file);
             done();
         } else {
-            uncss(options.html, { raw: String(file.contents), ignore: options.ignore, timeout: options.timeout }, function(err, output) {
+            uncss(options.html, { raw: String(file.contents), ignore: options.ignore, timeout: options.timeout, ignoreSheets: [/\s*/] }, function(err, output) {
                 if (err) {
                     stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
                 }


### PR DESCRIPTION
By default UnCSS takes html files as input and extracts stylesheets from them.
Since we already explicitly specify stylesheets as gulp.src option AND UnCSS uses default behavior, it can (and in fact is in my case) create duplicated output. 
For example in my **index.html** file i have this:

``` html
<link rel="stylesheet" href="css/normalize.css">
<link rel="stylesheet" href="css/main.css">
```

my **gulpfile.js** looks like this:

``` js
gulp.src(['css/normalize.css', 'css/main.css'])
        .pipe(concat('style.css'))
        .pipe(uncss({
            html: ['index.html']
        }))
        .pipe(gulp.dest('build'));
```

and i got this **style.css**:

```
<output from normalize.css>
<output from main.css>
<output from normalize.css>
<output from main.css>
```
