### PR TITLE
Lock UnCSS to v0.8.1 due to stability issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bufferstreams": "0.0.2",
     "gulp-util": "~2.2.14",
     "object-assign": "^0.3.0",
-    "uncss": "~0.8.1"
+    "uncss": "0.8.1"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
In line with changes made in grunt-uncss (https://github.com/addyosmani/grunt-uncss/pull/111), it might be a good idea to lock UnCSS to version 0.8.1 as there seem to be stability issues with later versions.

Log with example of issue encountered: https://travis-ci.org/javiercejudo/javiercejudo.com/jobs/29311660 (see line 1198) 
