### PR TITLE
Bring UnCSS up to date with upstream. Fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,56 +12,47 @@ npm install gulp-uncss --save-dev
 
 ## Example
 
+Single files, globbing patterns and URLs are all supported by gulp-uncss, and can be mixed and matched:
+
 ```js
 var gulp = require('gulp');
 var uncss = require('gulp-uncss');
 
-gulp.task('simple', function() {
+gulp.task('default', function() {
     return gulp.src('site.css')
         .pipe(uncss({
-            html: ['index.html', 'about.html']
+            html: ['index.html', 'posts/**/*.html', 'http://example.com']
         }))
         .pipe(gulp.dest('./out'));
 });
 ```
 
-## Glob example
-
-UnCSS does not provide native support for globbing patterns. If you would like gulp-uncss to parse a directory recursively, then you can use the [glob module](https://www.npmjs.org/package/glob) like so:
+gulp-uncss can also be used in a pipeline that involves CSS pre-processing. Utilising many transforms on a single file is one of gulp's strengths:
 
 ```js
-var glob = require('glob');
+var gulp = require('gulp');
+var uncss = require('gulp-uncss');
+var sass = require('gulp-sass');
+var concat = require('gulp-concat');
+var csso = require('gulp-csso');
 
-gulp.task('glob', function() {
-    gulp.src('site.css')
+gulp.task('default', function() {
+    return gulp.src('styles/**/*.scss')
+        .pipe(sass())
+        .pipe(concat('main.css'))
         .pipe(uncss({
-            html: glob.sync('templates/**/*.html')
+            html: ['index.html', 'posts/**/*.html', 'http://example.com']
         }))
+        .pipe(csso())
         .pipe(gulp.dest('./out'));
 });
 ```
 
-## URL example
-
-UnCSS can also visit your website for the HTML it uses to analyse the CSS against. Here is an example:
-
-```js
-gulp.task('urls', function() {
-    gulp.src('site.css')
-        .pipe(uncss({
-            html: [
-                'http://www.example.com'
-            ]
-        }))
-        .pipe(gulp.dest('./out'));
-});
-```
-
-Note that you can mix and match URLs and paths to files using the `html` option.
+In just a few lines, we compiled SCSS source into a single file, removed unused CSS and minified the output!
 
 ## Options
 
-This plugin takes slightly different options to the UnCSS module, because it is essentially just a streaming wrapper which returns a CSS stream.
+Please see the [UnCSS documentation](https://github.com/giakki/uncss#within-nodejs) for all of the options you can use. Some of them aren't as necessary when using gulp-uncss, because the CSS to analyse comes from the stream rather than the HTML files. The main options you will likely be using are:
 
 ### html
 Type: `Array|String`
@@ -80,6 +71,8 @@ Type: `Integer`
 Default value: `undefined`
 
 Specify how long to wait for the JS to be loaded.
+
+Note that `options.ignoreSheets` is *already defined* for you. gulp-uncss will only process CSS files in the stream.
 
 ## Contributing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,24 +2,20 @@
 
 'use strict';
 
-var gulp    = require('gulp'),
-    gutil   = require('gulp-util'),
-    clear   = require('clear'),
-    mocha   = require('gulp-mocha'),
-    jshint  = require('gulp-jshint');
+var gulp   = require('gulp'),
+    mocha  = require('gulp-mocha'),
+    jshint = require('gulp-jshint');
 
-gulp.task('lint', function () {
-    gulp.src('*.js')
-        .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'))
-        .pipe(mocha());
-});
+gulp.task('develop', function() {
+    function scripts() {
+        return gulp.src('*.js')
+            .pipe(jshint())
+            .pipe(jshint.reporter('jshint-stylish'))
+            .pipe(mocha({ reporter: 'mocha-silent-reporter' }));
+    }
 
-gulp.task('default', function() {
-    gulp.run('lint');
-    gulp.watch('*.js', function(event) {
-        clear();
-        gutil.log(gutil.colors.cyan(event.path.replace(process.cwd(), '')) + ' ' + event.type + '. (' + gutil.colors.magenta(gutil.date('HH:MM:ss')) + ')');
-        gulp.run('lint');
-    });
+    var watcher = gulp.watch('*.js');
+    watcher.on('change', scripts);
+
+    return scripts();
 });

--- a/index.js
+++ b/index.js
@@ -2,27 +2,24 @@
 
 'use strict';
 
-var uncss           = require('uncss'),
-    gutil           = require('gulp-util'),
-    transform       = require('stream').Transform,
-    objectAssign    = require('object-assign'),
+var uncss       = require('uncss'),
+    gutil       = require('gulp-util'),
+    assign      = require('object-assign'),
+    transform   = require('stream').Transform,
 
-    PLUGIN_NAME     = 'gulp-uncss';
+    PLUGIN_NAME = 'gulp-uncss';
 
-module.exports = function() {
+module.exports = function(options) {
     var stream = new transform({ objectMode: true });
-    var options = {
-        html: arguments[0].html,
-        ignore: arguments[0].ignore,
-        timeout: arguments[0].timeout,
-        ignoreSheets: [/\s*/]
-    };
+
+    // Ignore stylesheets in the HTML files; only use those from the stream
+    options.ignoreSheets = [/\s*/];
 
     stream._transform = function(file, unused, done) {
         if (file.isStream()) {
             return done(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
         } else if (file.isBuffer()) {
-            uncss(options.html, objectAssign(options, { raw: String(file.contents) }), function(err, output) {
+            uncss(options.html, assign(options, { raw: String(file.contents) }), function(err, output) {
                 if (err) {
                     return done(new gutil.PluginError(PLUGIN_NAME, err));
                 }
@@ -36,4 +33,4 @@ module.exports = function() {
     };
 
     return stream;
-}
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "gulp-util": "~3.0.1",
     "object-assign": "^2.0.0",
-    "uncss": "^0.11.0"
+    "uncss": "^0.12.0"
   },
   "devDependencies": {
     "chai": "~1.10.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
   },
   "devDependencies": {
     "chai": "~1.10.0",
+    "event-stream": "~3.2.1",
     "gulp": "~3.8.10",
-    "gulp-mocha": "~2.0.0",
     "gulp-jshint": "~1.9.0",
+    "gulp-mocha": "~2.0.0",
     "jshint-stylish": "~1.0.0",
     "mocha": "~2.1.0",
-    "event-stream": "~3.2.1"
+    "mocha-silent-reporter": "^1.0.0"
   },
   "main": "index.js"
 }

--- a/package.json
+++ b/package.json
@@ -24,17 +24,16 @@
   "dependencies": {
     "gulp-util": "~3.0.1",
     "object-assign": "^2.0.0",
-    "uncss": "0.8.1"
+    "uncss": "^0.11.0"
   },
   "devDependencies": {
-    "chai": "~1.9.1",
-    "clear": "0.0.1",
-    "gulp": "~3.5.6",
-    "gulp-mocha": "~0.4.1",
-    "gulp-jshint": "~1.5.0",
-    "jshint-stylish": "~0.1.5",
-    "mocha": "~1.18.2",
-    "event-stream": "~3.1.0"
+    "chai": "~1.10.0",
+    "gulp": "~3.8.10",
+    "gulp-mocha": "~2.0.0",
+    "gulp-jshint": "~1.9.0",
+    "jshint-stylish": "~1.0.0",
+    "mocha": "~2.1.0",
+    "event-stream": "~3.2.1"
   },
   "main": "index.js"
 }

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@
 
 var expect = require('chai').expect,
     gutil  = require('gulp-util'),
-    uncss  = require('./index'),
+    uncss  = require('./'),
     Stream = require('stream'),
     es     = require('event-stream'),
 


### PR DESCRIPTION
This patch fixes the following:

* Finally bumping UnCSS from `0.8.1`!
* Documentation fixed mostly. Better examples for demonstrating glob and url support.
* Now the full options object is passed to UnCSS; if people would like to use `uncssrc` etc, they are welcome.
* Updated build process and dev dependencies.

Once we're all happy on https://github.com/giakki/uncss/issues/111 I'll merge this (with the updated version) and release as `1.0.0` - in the meantime you are welcome to try this out in your build processes. :smile: